### PR TITLE
Update httparty version to 0.21.0

### DIFF
--- a/genius.gemspec
+++ b/genius.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr",       "~> 2.5.0"
   spec.add_development_dependency "rubocop",   "~> 0.31.0"
 
-  spec.add_runtime_dependency     "httparty",  "~> 0.11.0"
+  spec.add_runtime_dependency     "httparty",  "~> 0.21.0"
 end


### PR DESCRIPTION
Version `0.11.0` of `httparty` gem contains deprecated escaping that generates a warning:

```
/gems/httparty-0.11.0/lib/httparty/hash_conversions.rb:35: warning: URI.escape is obsolete
```